### PR TITLE
Almalinux auto-update - 150244

### DIFF
--- a/library/almalinux
+++ b/library/almalinux
@@ -1,3 +1,4 @@
+# This file is generated using https://github.com/almalinux/docker-images/blob//script.sh
 Maintainers: The AlmaLinux OS Foundation <cloud-infra@almalinux.org> (@AlmaLinux)
 GitRepo: https://github.com/AlmaLinux/docker-images.git
 
@@ -47,32 +48,32 @@ s390x-GitCommit: 65b999f771d43638c576c1e2baf4c5e15027abcc
 s390x-File: Dockerfile-s390x-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
 
-Tags: 9, 9.0, 9.0-20220901
-GitFetch: refs/heads/al9-20220901-amd64
-GitCommit: 824c8437333f8dda7888a0d3b745dadd75723fdc
+Tags: 9, 9.0, 9.0-20220914
+GitFetch: refs/heads/al9-20220914-amd64
+GitCommit: 
 amd64-File: Dockerfile-x86_64-default
-arm64v8-GitFetch: refs/heads/al9-20220901-arm64v8
-arm64v8-GitCommit: c5eafd4dbc9500a073f9846afd8e940dc77fb73d
+arm64v8-GitFetch: refs/heads/al9-20220914-arm64v8
+arm64v8-GitCommit: 
 arm64v8-File: Dockerfile-aarch64-default
-ppc64le-GitFetch: refs/heads/al9-20220901-ppc64le
-ppc64le-GitCommit: f4af629d22f7aa5dd24b7998c2e6bd63559ccff0
+ppc64le-GitFetch: refs/heads/al9-20220914-ppc64le
+ppc64le-GitCommit: 
 ppc64le-File: Dockerfile-ppc64le-default
-s390x-GitFetch: refs/heads/al9-20220901-s390x
-s390x-GitCommit: 7f7e861e8ac438aaa8c4ba7b7fa4c351c6d5e3c8
+s390x-GitFetch: refs/heads/al9-20220914-s390x
+s390x-GitCommit: 
 s390x-File: Dockerfile-s390x-default
 Architectures: amd64, arm64v8, ppc64le, s390x
 
-Tags: 9-minimal,  9.0-minimal, 9.0-minimal-20220901
-GitFetch: refs/heads/al9-20220901-amd64
-GitCommit: 824c8437333f8dda7888a0d3b745dadd75723fdc
+Tags: 9-minimal,  9.0-minimal, 9.0-minimal-20220914
+GitFetch: refs/heads/al9-20220914-amd64
+GitCommit: 
 amd64-File: Dockerfile-x86_64-minimal
-arm64v8-GitFetch: refs/heads/al9-20220901-arm64v8
-arm64v8-GitCommit: c5eafd4dbc9500a073f9846afd8e940dc77fb73d
+arm64v8-GitFetch: refs/heads/al9-20220914-arm64v8
+arm64v8-GitCommit: 
 arm64v8-File: Dockerfile-aarch64-minimal
-ppc64le-GitFetch: refs/heads/al9-20220901-ppc64le
-ppc64le-GitCommit: f4af629d22f7aa5dd24b7998c2e6bd63559ccff0
+ppc64le-GitFetch: refs/heads/al9-20220914-ppc64le
+ppc64le-GitCommit: 
 ppc64le-File: Dockerfile-ppc64le-minimal
-s390x-GitFetch: refs/heads/al9-20220901-s390x
-s390x-GitCommit: 7f7e861e8ac438aaa8c4ba7b7fa4c351c6d5e3c8
+s390x-GitFetch: refs/heads/al9-20220914-s390x
+s390x-GitCommit: 
 s390x-File: Dockerfile-s390x-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x


### PR DESCRIPTION
- `bash` changed from 4.4.20-3.el8 to 4.4.20-4.el8_6
- `curl` changed from 7.61.1-22.el8_6.3 to 7.61.1-22.el8_6.4
- `dbus` changed from 1.12.8-18.el8 to 1.12.8-18.el8_6.1
- `dbus-common` changed from 1.12.8-18.el8 to 1.12.8-18.el8_6.1
- `dbus-daemon` changed from 1.12.8-18.el8 to 1.12.8-18.el8_6.1
- `dbus-libs` changed from 1.12.8-18.el8 to 1.12.8-18.el8_6.1
- `dbus-tools` changed from 1.12.8-18.el8 to 1.12.8-18.el8_6.1
- `device-mapper` changed from 1.02.181-3.el8 to 1.02.181-3.el8_6.2
- `device-mapper-libs` changed from 1.02.181-3.el8 to 1.02.181-3.el8_6.2
- `libcurl-minimal` changed from 7.61.1-22.el8_6.3 to 7.61.1-22.el8_6.4
- `libdnf` changed from 0.63.0-8.el8.alma to 0.63.0-8.1.el8_6.alma
- `openssl-libs` changed from 1.1.1k-6.el8_5 to 1.1.1k-7.el8_6
- `pcre2` changed from 10.32-2.el8 to 10.32-3.el8_6
- `python3-hawkey` changed from 0.63.0-8.el8.alma to 0.63.0-8.1.el8_6.alma
- `python3-libdnf` changed from 0.63.0-8.el8.alma to 0.63.0-8.1.el8_6.alma
- `systemd` changed from 239-58.el8 to 239-58.el8_6.4
- `systemd-libs` changed from 239-58.el8 to 239-58.el8_6.4
- `systemd-pam` changed from 239-58.el8 to 239-58.el8_6.4
- `tzdata` changed from 2022a-1.el8 to 2022c-1.el8
- `vim-minimal` changed from 8.0.1763-19.el8_6.2 to 8.0.1763-19.el8_6.4
