### PR TITLE
Almalinux auto-update - 093852

### DIFF
--- a/library/almalinux
+++ b/library/almalinux
@@ -1,3 +1,4 @@
+# This file is generated using https://github.com/almalinux/docker-images/blob//script.sh
 Maintainers: The AlmaLinux OS Foundation <cloud-infra@almalinux.org> (@AlmaLinux)
 GitRepo: https://github.com/AlmaLinux/docker-images.git
 
@@ -17,62 +18,62 @@ arm64v8-File: Dockerfile-aarch64-minimal
 ppc64le-File: Dockerfile-ppc64le-minimal
 Architectures: amd64, arm64v8, ppc64le
 
-Tags: latest, 8, 8.6, 8.6-20220901
-GitFetch: refs/heads/al8-20220901-amd64
-GitCommit: 1ff60edf414285a260ad40a050841f66f8cb6ad8
+Tags: latest, 8, 8.6, 8.6-20220914
+GitFetch: refs/heads/al8-20220914-amd64
+GitCommit: 
 amd64-File: Dockerfile-x86_64-default
-arm64v8-GitFetch: refs/heads/al8-20220901-arm64v8
-arm64v8-GitCommit: 6b53409c7c9d54ffde8eb5013f9159c4eec9706a
+arm64v8-GitFetch: refs/heads/al8-20220914-arm64v8
+arm64v8-GitCommit: 
 arm64v8-File: Dockerfile-aarch64-default
-ppc64le-GitFetch: refs/heads/al8-20220901-ppc64le
-ppc64le-GitCommit: e70edacf650f2439b82fcbe72886d911a91c8f14
+ppc64le-GitFetch: refs/heads/al8-20220914-ppc64le
+ppc64le-GitCommit: 
 ppc64le-File: Dockerfile-ppc64le-default
-s390x-GitFetch: refs/heads/al8-20220901-s390x
-s390x-GitCommit: 65b999f771d43638c576c1e2baf4c5e15027abcc
+s390x-GitFetch: refs/heads/al8-20220914-s390x
+s390x-GitCommit: 
 s390x-File: Dockerfile-s390x-default
 Architectures: amd64, arm64v8, ppc64le, s390x
 
-Tags: minimal, 8-minimal, 8.6-minimal, 8.6-minimal-20220901
-GitFetch: refs/heads/al8-20220901-amd64
-GitCommit: 1ff60edf414285a260ad40a050841f66f8cb6ad8
+Tags: minimal, 8-minimal, 8.6-minimal, 8.6-minimal-20220914
+GitFetch: refs/heads/al8-20220914-amd64
+GitCommit: 
 amd64-File: Dockerfile-x86_64-minimal
-arm64v8-GitFetch: refs/heads/al8-20220901-arm64v8
-arm64v8-GitCommit: 6b53409c7c9d54ffde8eb5013f9159c4eec9706a
+arm64v8-GitFetch: refs/heads/al8-20220914-arm64v8
+arm64v8-GitCommit: 
 arm64v8-File: Dockerfile-aarch64-minimal
-ppc64le-GitFetch: refs/heads/al8-20220901-ppc64le
-ppc64le-GitCommit: e70edacf650f2439b82fcbe72886d911a91c8f14
+ppc64le-GitFetch: refs/heads/al8-20220914-ppc64le
+ppc64le-GitCommit: 
 ppc64le-File: Dockerfile-ppc64le-minimal
-s390x-GitFetch: refs/heads/al8-20220901-s390x
-s390x-GitCommit: 65b999f771d43638c576c1e2baf4c5e15027abcc
+s390x-GitFetch: refs/heads/al8-20220914-s390x
+s390x-GitCommit: 
 s390x-File: Dockerfile-s390x-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
 
-Tags: 9, 9.0, 9.0-20220901
-GitFetch: refs/heads/al9-20220901-amd64
-GitCommit: 824c8437333f8dda7888a0d3b745dadd75723fdc
+Tags: 9, 9.0, 9.0-20220914
+GitFetch: refs/heads/al9-20220914-amd64
+GitCommit: 
 amd64-File: Dockerfile-x86_64-default
-arm64v8-GitFetch: refs/heads/al9-20220901-arm64v8
-arm64v8-GitCommit: c5eafd4dbc9500a073f9846afd8e940dc77fb73d
+arm64v8-GitFetch: refs/heads/al9-20220914-arm64v8
+arm64v8-GitCommit: 
 arm64v8-File: Dockerfile-aarch64-default
-ppc64le-GitFetch: refs/heads/al9-20220901-ppc64le
-ppc64le-GitCommit: f4af629d22f7aa5dd24b7998c2e6bd63559ccff0
+ppc64le-GitFetch: refs/heads/al9-20220914-ppc64le
+ppc64le-GitCommit: 
 ppc64le-File: Dockerfile-ppc64le-default
-s390x-GitFetch: refs/heads/al9-20220901-s390x
-s390x-GitCommit: 7f7e861e8ac438aaa8c4ba7b7fa4c351c6d5e3c8
+s390x-GitFetch: refs/heads/al9-20220914-s390x
+s390x-GitCommit: 
 s390x-File: Dockerfile-s390x-default
 Architectures: amd64, arm64v8, ppc64le, s390x
 
-Tags: 9-minimal,  9.0-minimal, 9.0-minimal-20220901
-GitFetch: refs/heads/al9-20220901-amd64
-GitCommit: 824c8437333f8dda7888a0d3b745dadd75723fdc
+Tags: 9-minimal,  9.0-minimal, 9.0-minimal-20220914
+GitFetch: refs/heads/al9-20220914-amd64
+GitCommit: 
 amd64-File: Dockerfile-x86_64-minimal
-arm64v8-GitFetch: refs/heads/al9-20220901-arm64v8
-arm64v8-GitCommit: c5eafd4dbc9500a073f9846afd8e940dc77fb73d
+arm64v8-GitFetch: refs/heads/al9-20220914-arm64v8
+arm64v8-GitCommit: 
 arm64v8-File: Dockerfile-aarch64-minimal
-ppc64le-GitFetch: refs/heads/al9-20220901-ppc64le
-ppc64le-GitCommit: f4af629d22f7aa5dd24b7998c2e6bd63559ccff0
+ppc64le-GitFetch: refs/heads/al9-20220914-ppc64le
+ppc64le-GitCommit: 
 ppc64le-File: Dockerfile-ppc64le-minimal
-s390x-GitFetch: refs/heads/al9-20220901-s390x
-s390x-GitCommit: 7f7e861e8ac438aaa8c4ba7b7fa4c351c6d5e3c8
+s390x-GitFetch: refs/heads/al9-20220914-s390x
+s390x-GitCommit: 
 s390x-File: Dockerfile-s390x-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x


### PR DESCRIPTION
This is auto-generated commit, any concern or issue, please contact @srbala or email to AlmaLinux OS Foundation <cloud-infra@almalinux.org> (@AlmaLinux)


### AlmaLinux 9 change log

- `curl-minimal` changed from 7.76.1-14.el9_0.4 to 7.76.1-14.el9_0.5
- `libcurl-minimal` changed from 7.76.1-14.el9_0.4 to 7.76.1-14.el9_0.5
- `openssl` changed from 3.0.1-23.el9_0 to 3.0.1-41.el9_0
- `openssl-libs` changed from 3.0.1-23.el9_0 to 3.0.1-41.el9_0
- `tzdata` changed from 2022a-1.el9_0 to 2022c-1.el9_0
- `vim-minimal` changed from 8.2.2637-16.el9_0.2 to 8.2.2637-16.el9_0.3

