### PR TITLE
Almalinux auto-update - 041215

### DIFF
--- a/library/almalinux
+++ b/library/almalinux
@@ -1,3 +1,4 @@
+# This file is generated using https://github.com/almalinux/docker-images/blob/94e2f6f3b2cb6e72d7392e7848eeae383b017353/gen_docker_official_library
 Maintainers: The AlmaLinux OS Foundation <cloud-infra@almalinux.org> (@AlmaLinux)
 GitRepo: https://github.com/AlmaLinux/docker-images.git
 
@@ -17,33 +18,33 @@ arm64v8-File: Dockerfile-aarch64-minimal
 ppc64le-File: Dockerfile-ppc64le-minimal
 Architectures: amd64, arm64v8, ppc64le
 
-Tags: latest, 8, 8.6, 8.6-20220901
-GitFetch: refs/heads/al8-20220901-amd64
-GitCommit: 1ff60edf414285a260ad40a050841f66f8cb6ad8
+Tags: latest, 8, 8.6, 8.6-20220903
+GitFetch: refs/heads/al8-20220903-amd64
+GitCommit: 691421ad0af1ca0aaafd60dbddd9750a3cae8e63
 amd64-File: Dockerfile-x86_64-default
-arm64v8-GitFetch: refs/heads/al8-20220901-arm64v8
-arm64v8-GitCommit: 6b53409c7c9d54ffde8eb5013f9159c4eec9706a
+arm64v8-GitFetch: refs/heads/al8-20220903-arm64v8
+arm64v8-GitCommit: 0fb50f272f4b579344681841af16c21c6b8c0b4d
 arm64v8-File: Dockerfile-aarch64-default
-ppc64le-GitFetch: refs/heads/al8-20220901-ppc64le
-ppc64le-GitCommit: e70edacf650f2439b82fcbe72886d911a91c8f14
+ppc64le-GitFetch: refs/heads/al8-20220903-ppc64le
+ppc64le-GitCommit: 6396c1decb237c9e920327809df15fba4c39a51b
 ppc64le-File: Dockerfile-ppc64le-default
-s390x-GitFetch: refs/heads/al8-20220901-s390x
-s390x-GitCommit: 65b999f771d43638c576c1e2baf4c5e15027abcc
+s390x-GitFetch: refs/heads/al8-20220903-s390x
+s390x-GitCommit: ee78d7767058dfd0a7edab53e456a62b5f56ca11
 s390x-File: Dockerfile-s390x-default
 Architectures: amd64, arm64v8, ppc64le, s390x
 
-Tags: minimal, 8-minimal, 8.6-minimal, 8.6-minimal-20220901
-GitFetch: refs/heads/al8-20220901-amd64
-GitCommit: 1ff60edf414285a260ad40a050841f66f8cb6ad8
+Tags: minimal, 8-minimal, 8.6-minimal, 8.6-minimal-20220903
+GitFetch: refs/heads/al8-20220903-amd64
+GitCommit: 691421ad0af1ca0aaafd60dbddd9750a3cae8e63
 amd64-File: Dockerfile-x86_64-minimal
-arm64v8-GitFetch: refs/heads/al8-20220901-arm64v8
-arm64v8-GitCommit: 6b53409c7c9d54ffde8eb5013f9159c4eec9706a
+arm64v8-GitFetch: refs/heads/al8-20220903-arm64v8
+arm64v8-GitCommit: 0fb50f272f4b579344681841af16c21c6b8c0b4d
 arm64v8-File: Dockerfile-aarch64-minimal
-ppc64le-GitFetch: refs/heads/al8-20220901-ppc64le
-ppc64le-GitCommit: e70edacf650f2439b82fcbe72886d911a91c8f14
+ppc64le-GitFetch: refs/heads/al8-20220903-ppc64le
+ppc64le-GitCommit: 6396c1decb237c9e920327809df15fba4c39a51b
 ppc64le-File: Dockerfile-ppc64le-minimal
-s390x-GitFetch: refs/heads/al8-20220901-s390x
-s390x-GitCommit: 65b999f771d43638c576c1e2baf4c5e15027abcc
+s390x-GitFetch: refs/heads/al8-20220903-s390x
+s390x-GitCommit: ee78d7767058dfd0a7edab53e456a62b5f56ca11
 s390x-File: Dockerfile-s390x-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
 


### PR DESCRIPTION
This is auto-generated commit, any concern or issue, please contact @srbala or email to AlmaLinux OS Foundation <cloud-infra@almalinux.org> (@AlmaLinux)

### AlmaLinux 8 change log

- `bash` changed from 4.4.20-3.el8 to 4.4.20-4.el8_6
- `curl` changed from 7.61.1-22.el8_6.3 to 7.61.1-22.el8_6.4
- `dbus` changed from 1.12.8-18.el8 to 1.12.8-18.el8_6.1
- `dbus-common` changed from 1.12.8-18.el8 to 1.12.8-18.el8_6.1
- `dbus-daemon` changed from 1.12.8-18.el8 to 1.12.8-18.el8_6.1
- `dbus-libs` changed from 1.12.8-18.el8 to 1.12.8-18.el8_6.1
- `dbus-tools` changed from 1.12.8-18.el8 to 1.12.8-18.el8_6.1
- `device-mapper` changed from 1.02.181-3.el8 to 1.02.181-3.el8_6.2
- `device-mapper-libs` changed from 1.02.181-3.el8 to 1.02.181-3.el8_6.2
- `libcurl-minimal` changed from 7.61.1-22.el8_6.3 to 7.61.1-22.el8_6.4
- `libdnf` changed from 0.63.0-8.el8.alma to 0.63.0-8.1.el8_6.alma
- `openssl-libs` changed from 1.1.1k-6.el8_5 to 1.1.1k-7.el8_6
- `pcre2` changed from 10.32-2.el8 to 10.32-3.el8_6
- `python3-hawkey` changed from 0.63.0-8.el8.alma to 0.63.0-8.1.el8_6.alma
- `python3-libdnf` changed from 0.63.0-8.el8.alma to 0.63.0-8.1.el8_6.alma
- `systemd` changed from 239-58.el8 to 239-58.el8_6.4
- `systemd-libs` changed from 239-58.el8 to 239-58.el8_6.4
- `systemd-pam` changed from 239-58.el8 to 239-58.el8_6.4
- `tzdata` changed from 2022a-1.el8 to 2022c-1.el8
- `vim-minimal` changed from 8.0.1763-19.el8_6.2 to 8.0.1763-19.el8_6.4


