### PR TITLE
Almalinux auto-update - 080612

### DIFF
--- a/library/almalinux
+++ b/library/almalinux
@@ -1,3 +1,4 @@
+# This file is generated using https://github.com/almalinux/docker-images/blob/17890ec5023d2925b24b95b321c7e8d27154c33b/gen_docker_official_library
 Maintainers: The AlmaLinux OS Foundation <cloud-infra@almalinux.org> (@AlmaLinux)
 GitRepo: https://github.com/AlmaLinux/docker-images.git
 
@@ -17,62 +18,62 @@ arm64v8-File: Dockerfile-aarch64-minimal
 ppc64le-File: Dockerfile-ppc64le-minimal
 Architectures: amd64, arm64v8, ppc64le
 
-Tags: latest, 8, 8.6, 8.6-20220901
-GitFetch: refs/heads/al8-20220901-amd64
-GitCommit: 1ff60edf414285a260ad40a050841f66f8cb6ad8
+Tags: latest, 8, 8.6, 8.6-20220925
+GitFetch: refs/heads/al8-20220925-amd64
+GitCommit: 646cacf057bc1d1b01b0fa902a35e3d080c7119a
 amd64-File: Dockerfile-x86_64-default
-arm64v8-GitFetch: refs/heads/al8-20220901-arm64v8
-arm64v8-GitCommit: 6b53409c7c9d54ffde8eb5013f9159c4eec9706a
+arm64v8-GitFetch: refs/heads/al8-20220925-arm64v8
+arm64v8-GitCommit: ca0bfc0459fe91eca71ede0410bd10a0caa2e4ab
 arm64v8-File: Dockerfile-aarch64-default
-ppc64le-GitFetch: refs/heads/al8-20220901-ppc64le
-ppc64le-GitCommit: e70edacf650f2439b82fcbe72886d911a91c8f14
+ppc64le-GitFetch: refs/heads/al8-20220925-ppc64le
+ppc64le-GitCommit: 676ef27b16a0ff98c790c04560373af39e390a75
 ppc64le-File: Dockerfile-ppc64le-default
-s390x-GitFetch: refs/heads/al8-20220901-s390x
-s390x-GitCommit: 65b999f771d43638c576c1e2baf4c5e15027abcc
+s390x-GitFetch: refs/heads/al8-20220925-s390x
+s390x-GitCommit: 270a869170317907043ab7b47e78c9d2e7395601
 s390x-File: Dockerfile-s390x-default
 Architectures: amd64, arm64v8, ppc64le, s390x
 
-Tags: minimal, 8-minimal, 8.6-minimal, 8.6-minimal-20220901
-GitFetch: refs/heads/al8-20220901-amd64
-GitCommit: 1ff60edf414285a260ad40a050841f66f8cb6ad8
+Tags: minimal, 8-minimal, 8.6-minimal, 8.6-minimal-20220925
+GitFetch: refs/heads/al8-20220925-amd64
+GitCommit: 646cacf057bc1d1b01b0fa902a35e3d080c7119a
 amd64-File: Dockerfile-x86_64-minimal
-arm64v8-GitFetch: refs/heads/al8-20220901-arm64v8
-arm64v8-GitCommit: 6b53409c7c9d54ffde8eb5013f9159c4eec9706a
+arm64v8-GitFetch: refs/heads/al8-20220925-arm64v8
+arm64v8-GitCommit: ca0bfc0459fe91eca71ede0410bd10a0caa2e4ab
 arm64v8-File: Dockerfile-aarch64-minimal
-ppc64le-GitFetch: refs/heads/al8-20220901-ppc64le
-ppc64le-GitCommit: e70edacf650f2439b82fcbe72886d911a91c8f14
+ppc64le-GitFetch: refs/heads/al8-20220925-ppc64le
+ppc64le-GitCommit: 676ef27b16a0ff98c790c04560373af39e390a75
 ppc64le-File: Dockerfile-ppc64le-minimal
-s390x-GitFetch: refs/heads/al8-20220901-s390x
-s390x-GitCommit: 65b999f771d43638c576c1e2baf4c5e15027abcc
+s390x-GitFetch: refs/heads/al8-20220925-s390x
+s390x-GitCommit: 270a869170317907043ab7b47e78c9d2e7395601
 s390x-File: Dockerfile-s390x-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
 
-Tags: 9, 9.0, 9.0-20220901
-GitFetch: refs/heads/al9-20220901-amd64
-GitCommit: 824c8437333f8dda7888a0d3b745dadd75723fdc
+Tags: 9, 9.0, 9.0-20220925
+GitFetch: refs/heads/al9-20220925-amd64
+GitCommit: 109e30b3f2ffec86b37d7d9f314e73c6db183599
 amd64-File: Dockerfile-x86_64-default
-arm64v8-GitFetch: refs/heads/al9-20220901-arm64v8
-arm64v8-GitCommit: c5eafd4dbc9500a073f9846afd8e940dc77fb73d
+arm64v8-GitFetch: refs/heads/al9-20220925-arm64v8
+arm64v8-GitCommit: 00708134ea20c9364d3e20734eda8101e7be16d2
 arm64v8-File: Dockerfile-aarch64-default
-ppc64le-GitFetch: refs/heads/al9-20220901-ppc64le
-ppc64le-GitCommit: f4af629d22f7aa5dd24b7998c2e6bd63559ccff0
+ppc64le-GitFetch: refs/heads/al9-20220925-ppc64le
+ppc64le-GitCommit: 36607afb4345bbcfa02bdc5aabf59c2eebbe5895
 ppc64le-File: Dockerfile-ppc64le-default
-s390x-GitFetch: refs/heads/al9-20220901-s390x
-s390x-GitCommit: 7f7e861e8ac438aaa8c4ba7b7fa4c351c6d5e3c8
+s390x-GitFetch: refs/heads/al9-20220925-s390x
+s390x-GitCommit: 86afce9f7f3b90427cc0253240bfea29f91d5407
 s390x-File: Dockerfile-s390x-default
 Architectures: amd64, arm64v8, ppc64le, s390x
 
-Tags: 9-minimal,  9.0-minimal, 9.0-minimal-20220901
-GitFetch: refs/heads/al9-20220901-amd64
-GitCommit: 824c8437333f8dda7888a0d3b745dadd75723fdc
+Tags: 9-minimal,  9.0-minimal, 9.0-minimal-20220925
+GitFetch: refs/heads/al9-20220925-amd64
+GitCommit: 109e30b3f2ffec86b37d7d9f314e73c6db183599
 amd64-File: Dockerfile-x86_64-minimal
-arm64v8-GitFetch: refs/heads/al9-20220901-arm64v8
-arm64v8-GitCommit: c5eafd4dbc9500a073f9846afd8e940dc77fb73d
+arm64v8-GitFetch: refs/heads/al9-20220925-arm64v8
+arm64v8-GitCommit: 00708134ea20c9364d3e20734eda8101e7be16d2
 arm64v8-File: Dockerfile-aarch64-minimal
-ppc64le-GitFetch: refs/heads/al9-20220901-ppc64le
-ppc64le-GitCommit: f4af629d22f7aa5dd24b7998c2e6bd63559ccff0
+ppc64le-GitFetch: refs/heads/al9-20220925-ppc64le
+ppc64le-GitCommit: 36607afb4345bbcfa02bdc5aabf59c2eebbe5895
 ppc64le-File: Dockerfile-ppc64le-minimal
-s390x-GitFetch: refs/heads/al9-20220901-s390x
-s390x-GitCommit: 7f7e861e8ac438aaa8c4ba7b7fa4c351c6d5e3c8
+s390x-GitFetch: refs/heads/al9-20220925-s390x
+s390x-GitCommit: 86afce9f7f3b90427cc0253240bfea29f91d5407
 s390x-File: Dockerfile-s390x-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x


### PR DESCRIPTION
This is auto-generated commit, any concern or issue, please contact @srbala or email to AlmaLinux OS Foundation <cloud-infra@almalinux.org> (@AlmaLinux)

### AlmaLinux 8 change log

- `ca-certificates` changed from 2021.2.50-80.0.el8_4 to 2022.2.54-80.2.el8_6
- `gnupg2` changed from 2.2.20-2.el8 to 2.2.20-3.el8_6
- `libdnf` changed from 0.63.0-8.1.el8_6.alma to 0.63.0-8.2.el8_6.alma
- `pam` changed from 1.3.1-16.el8 to 1.3.1-16.el8_6.1
- `platform-python` changed from 3.6.8-45.el8.alma to 3.6.8-47.el8_6.alma
- `python3-hawkey` changed from 0.63.0-8.1.el8_6.alma to 0.63.0-8.2.el8_6.alma
- `python3-libdnf` changed from 0.63.0-8.1.el8_6.alma to 0.63.0-8.2.el8_6.alma
- `python3-libs` changed from 3.6.8-45.el8.alma to 3.6.8-47.el8_6.alma
- `systemd` changed from 239-58.el8_6.4 to 239-58.el8_6.7
- `systemd-libs` changed from 239-58.el8_6.4 to 239-58.el8_6.7
- `systemd-pam` changed from 239-58.el8_6.4 to 239-58.el8_6.7

### AlmaLinux 9 change log

- `ca-certificates` changed from 2020.2.50-94.el9 to 2022.2.54-90.2.el9_0
- `cryptsetup-libs` changed from 2.4.3-4.el9 to 2.4.3-4.el9_0.1
- `dbus-broker` changed from 28-5.el9 to 28-5.1.el9_0
- `glibc` changed from 2.34-28.el9_0 to 2.34-28.el9_0.2
- `glibc-common` changed from 2.34-28.el9_0 to 2.34-28.el9_0.2
- `glibc-minimal-langpack` changed from 2.34-28.el9_0 to 2.34-28.el9_0.2
- `gnupg2` changed from 2.3.3-1.el9 to 2.3.3-2.el9_0
- `libdnf` changed from 0.65.0-5.el9_0.alma to 0.65.0-5.1.el9_0.alma
- `libevent-2.1.12-6.el9` package added
- `libgcrypt` changed from 1.10.0-4.el9_0 to 1.10.0-5.el9_0
- `openldap` changed from 2.4.59-4.el9_0 to 2.6.2-1.el9_0
- `openldap-compat-2.6.2-1.el9_0` package added
- `pam` changed from 1.5.1-9.el9 to 1.5.1-9.el9_0.1
- `python3-hawkey` changed from 0.65.0-5.el9_0.alma to 0.65.0-5.1.el9_0.alma
- `python3-libdnf` changed from 0.65.0-5.el9_0.alma to 0.65.0-5.1.el9_0.alma
- `systemd` changed from 250-6.el9_0 to 250-6.el9_0.1
- `systemd-libs` changed from 250-6.el9_0 to 250-6.el9_0.1
- `systemd-pam` changed from 250-6.el9_0 to 250-6.el9_0.1
- `systemd-rpm-macros` changed from 250-6.el9_0 to 250-6.el9_0.1

